### PR TITLE
CVE-2025-22870: proxy, http/httpproxy: do not mismatch IPv6 zone ids against hosts

### DIFF
--- a/vendor/golang.org/x/net/proxy/per_host.go
+++ b/vendor/golang.org/x/net/proxy/per_host.go
@@ -7,6 +7,7 @@ package proxy
 import (
 	"context"
 	"net"
+	"net/netip"
 	"strings"
 )
 
@@ -57,7 +58,8 @@ func (p *PerHost) DialContext(ctx context.Context, network, addr string) (c net.
 }
 
 func (p *PerHost) dialerForRequest(host string) Dialer {
-	if ip := net.ParseIP(host); ip != nil {
+	if nip, err := netip.ParseAddr(host); err == nil {
+		ip := net.IP(nip.AsSlice())
 		for _, net := range p.bypassNetworks {
 			if net.Contains(ip) {
 				return p.bypass
@@ -108,8 +110,8 @@ func (p *PerHost) AddFromString(s string) {
 			}
 			continue
 		}
-		if ip := net.ParseIP(host); ip != nil {
-			p.AddIP(ip)
+		if nip, err := netip.ParseAddr(host); err == nil {
+			p.AddIP(net.IP(nip.AsSlice()))
 			continue
 		}
 		if strings.HasPrefix(host, "*.") {


### PR DESCRIPTION
When matching against a host "example.com",
don't match an IPv6 address like "[1000::1%25.example.com]:80".

Thanks to Juho Forsén of Mattermost for reporting this issue.

Fixes CVE-2025-22870
For https://github.com/golang/go/issues/71984
Fixes [bsc#1238685](https://bugzilla.suse.com/show_bug.cgi?id=1238685)