### PR TITLE
http2: prevent hanging Transport due to bad SETTINGS frame

### DIFF
--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2843,6 +2843,9 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
 
 	var seenMaxConcurrentStreams bool
 	err := f.ForeachSetting(func(s Setting) error {
+		if err := s.Valid(); err != nil {
+			return err
+		}
 		switch s.ID {
 		case SettingMaxFrameSize:
 			cc.maxFrameSize = s.Val


### PR DESCRIPTION
This CL backports https://go.dev/cl/761581 to x/net.

Fixes golang/go#78476
Fixes CVE-2026-33814

Change-Id: Ied435a51fdd8664d41dae14d082c39c76a6a6964
Reviewed-on: https://go-review.googlesource.com/c/net/+/761640
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Nicholas Husin <husin@google.com>
Reviewed-by: Damien Neil <dneil@google.com>